### PR TITLE
sso関連の機能実装

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,11 +6,14 @@ AllCops:
 Style/FrozenStringLiteralComment:
   Enabled: false
 Metrics/LineLength:
-  Max: 120
+  Max: 160
 Metrics/AbcSize:
-  Enabled: true
-  Max: 20
+  Enabled: false
 Documentation:
   Enabled: false
 Naming/FileName:
   Enabled: false
+Style/AsciiComments:
+  Enabled: false
+Metrics/MethodLength:
+  Max: 20

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     sp-rails-saml (0.1.0)
+      ruby-saml
 
 GEM
   remote: https://rubygems.org/

--- a/app/controllers/saml/ssos_base_controller.rb
+++ b/app/controllers/saml/ssos_base_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Saml
+  class SsosBaseController < SamlBaseController
+    skip_forgery_protection only: %w[consume]
+
+    # POST /saml/metadata/:id
+    def consume
+      account = SpRailsSaml::Settings.account_class.find(params[:id])
+      saml_setting = account.saml_setting
+      saml_response = SpRailsSaml::SamlResponse.new(params[:SAMLResponse], saml_setting)
+
+      if saml_response.valid?
+        user = SpRailsSaml::Settings.user_class.find_by(email: saml_response.name_id)
+        raise LoginUserNotFound if user.blank?
+
+        sign_in_with_saml(user)
+      else
+        redirect_to saml_sign_in_path, alert: 'failed to login'
+      end
+    end
+
+    # GET /saml/metadata/:id
+    def metadata
+      account = SpRailsSaml::Settings.account_class.find(params[:id])
+      metadata = SpRailsSaml::Metadata.new(account: account)
+      render xml: metadata.generate
+    end
+  end
+end

--- a/app/controllers/saml/ssos_controller.rb
+++ b/app/controllers/saml/ssos_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Saml
+  class SsosController < SsosBaseController
+    # POST /saml/sso/:id
+    # def consume
+    #   super
+    # end
+
+    # GET /saml/metadata/:id
+    # def metadata
+    #   super
+    # end
+  end
+end

--- a/lib/generators/sp-rails-saml/config_generator.rb
+++ b/lib/generators/sp-rails-saml/config_generator.rb
@@ -15,11 +15,9 @@ module SpRailsSaml
     def default_initializer
       <<~RUBY
         SpRailsSaml::Settings.setup do |config|
-          config.sp_entity_id                   = ''
           config.name_identifier_format         = 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'
           config.authn_context                  = 'urn:oasis:names:tc:SAML:2.0:ac:classes:X509'
           config.authn_context_comparison       = 'exact'
-          config.assertion_consumer_service_url = ''
           config.user_class = User
           config.account_class = Account
         end

--- a/lib/generators/sp-rails-saml/controllers_generator.rb
+++ b/lib/generators/sp-rails-saml/controllers_generator.rb
@@ -8,6 +8,7 @@ module SpRailsSaml
 
     def create
       copy_file 'controllers/sessions_controller.rb', 'app/controllers/saml/sessions_controller.rb'
+      copy_file 'controllers/ssos_controller.rb', 'app/controllers/saml/ssos_controller.rb'
     end
   end
 end

--- a/lib/generators/templates/controllers/ssos_controller.rb
+++ b/lib/generators/templates/controllers/ssos_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Saml
+  class SsosController < SsosBaseController
+    # POST /saml/sso/:id
+    # def consume
+    #   super
+    # end
+
+    # GET /saml/metadata/:id
+    # def metadata
+    #   super
+    # end
+  end
+end

--- a/lib/sp-rails-saml.rb
+++ b/lib/sp-rails-saml.rb
@@ -1,7 +1,5 @@
 require 'ruby-saml'
 require 'sp-rails-saml/settings'
-require 'sp-rails-saml/authnrequest'
-require 'sp-rails-saml/saml_response'
 require 'sp-rails-saml/draw_routes'
 require 'generators/sp-rails-saml/config_generator'
 require 'generators/sp-rails-saml/controllers_generator'
@@ -14,9 +12,15 @@ module SpRailsSaml
   class Error < StandardError; end
 
   class SettingValidationError < Error; end
+
+  autoload :Authnrequest, File.expand_path('./sp-rails-saml/authnrequest', __dir__)
+  autoload :SamlResponse, File.expand_path('./sp-rails-saml/saml_response', __dir__)
+  autoload :Metadata, File.expand_path('./sp-rails-saml/metadata', __dir__)
 end
 
 module Saml
   autoload :SessionsController, File.expand_path('../app/controllers/saml/sessions_controller', __dir__)
   autoload :SessionsBaseController, File.expand_path('../app/controllers/saml/sessions_base_controller', __dir__)
+  autoload :SsosController, File.expand_path('../app/controllers/saml/ssos_controller', __dir__)
+  autoload :SsosBaseController, File.expand_path('../app/controllers/saml/ssos_base_controller', __dir__)
 end

--- a/lib/sp-rails-saml/authnrequest.rb
+++ b/lib/sp-rails-saml/authnrequest.rb
@@ -2,6 +2,14 @@ module SpRailsSaml
   # SAML2 Authentication.
   #
   class Authnrequest
+    # url_forを使用するためにincludeしている
+    # テスト時にエラーが発生するので定義されてない場合はスキップしたくdefined?(ActionView::Helpers)の場合のみinclude
+    if defined?(ActionView::Helpers)
+      include ActionView::Helpers
+      include ActionDispatch::Routing
+      include Rails.application.routes.url_helpers
+    end
+
     def initialize(saml_setting)
       @saml_setting = saml_setting
     end
@@ -16,8 +24,8 @@ module SpRailsSaml
     def ruby_saml_settings
       settings = OneLogin::RubySaml::Settings.new
 
-      settings.assertion_consumer_service_url = SpRailsSaml::Settings.assertion_consumer_service_url
-      settings.sp_entity_id                   = SpRailsSaml::Settings.sp_entity_id
+      settings.assertion_consumer_service_url = saml_sso_url(id: @saml_setting.send(SpRailsSaml::Settings.account_class.to_s.downcase.to_sym).id)
+      settings.sp_entity_id                   = saml_metadata_url(id: @saml_setting.send(SpRailsSaml::Settings.account_class.to_s.downcase.to_sym).id)
       settings.name_identifier_format         = SpRailsSaml::Settings.name_identifier_format
       settings.authn_context                  = SpRailsSaml::Settings.authn_context
       settings.authn_context_comparison       = SpRailsSaml::Settings.authn_context_comparison

--- a/lib/sp-rails-saml/metadata.rb
+++ b/lib/sp-rails-saml/metadata.rb
@@ -1,0 +1,39 @@
+module SpRailsSaml
+  class Metadata
+    # url_forを使用するためにincludeしている
+    # テスト時にエラーが発生するので定義されてない場合はスキップしたくdefined?(ActionView::Helpers)の場合のみinclude
+    if defined?(ActionView::Helpers)
+      include ActionView::Helpers
+      include ActionDispatch::Routing
+      include Rails.application.routes.url_helpers
+    end
+
+    def initialize(account:)
+      @account = account
+    end
+
+    def generate
+      metadata = OneLogin::RubySaml::Metadata.new
+      metadata.generate(ruby_saml_settings)
+    end
+
+    private
+
+    def required_value_is_set?
+      SpRailsSaml::Settings.name_identifier_format
+    end
+
+    def ruby_saml_settings
+      raise SettingValidationError, 'lack of required setting value' unless required_value_is_set?
+
+      settings = OneLogin::RubySaml::Settings.new
+
+      settings.assertion_consumer_service_url     = saml_sso_url(@account.id)
+      settings.sp_entity_id                       = saml_metadata_url(@account.id)
+      settings.name_identifier_format             = SpRailsSaml::Settings.name_identifier_format
+      settings.security[:want_assertions_signed]  =
+        SpRailsSaml::Settings::RUBY_SAML_DEFAULT_SETTINGS[:want_assertions_signed]
+      settings
+    end
+  end
+end

--- a/lib/sp-rails-saml/routes/routes_template.rb
+++ b/lib/sp-rails-saml/routes/routes_template.rb
@@ -1,4 +1,6 @@
 namespace :saml do
   get 'sign_in', to: 'sessions#new'
   post 'sign_in', to: 'sessions#create'
+  post 'sso/:id', to: 'ssos#consume', as: :sso
+  get 'metadata/:id', to: 'ssos#metadata', as: :metadata
 end

--- a/lib/sp-rails-saml/saml_response.rb
+++ b/lib/sp-rails-saml/saml_response.rb
@@ -2,10 +2,24 @@ module SpRailsSaml
   # SAML2 Authentication Response.
   #
   class SamlResponse
+    # url_forを使用するためにincludeしている
+    # テスト時にエラーが発生するので定義されてない場合はスキップしたくdefined?(ActionView::Helpers)の場合のみinclude
+    if defined?(ActionView::Helpers)
+      include ActionView::Helpers
+      include ActionDispatch::Routing
+      include Rails.application.routes.url_helpers
+    end
+
     def initialize(saml_response, saml_setting)
       @saml_setting = saml_setting
+      @saml_response = saml_response
+    end
+
+    def response
+      return @response if @response.present?
+
       @response = OneLogin::RubySaml::Response.new(
-        saml_response,
+        @saml_response,
         settings: ruby_saml_settings,
         skip_subject_confirmation: SpRailsSaml::Settings::RUBY_SAML_DEFAULT_SETTINGS[:skip_subject_confirmation],
         skip_conditions: SpRailsSaml::Settings::RUBY_SAML_DEFAULT_SETTINGS[:skip_conditions]
@@ -13,36 +27,36 @@ module SpRailsSaml
     end
 
     def valid?
-      @response.is_valid?
+      response.is_valid?
     end
 
     def name_id
-      @response.name_id
+      response.name_id
     end
 
     def name_id_format
-      @response.name_id_format
+      response.name_id_format
     end
 
     def errors
-      @response.errors
+      response.errors
     end
 
     private
 
     def required_value_is_set?
-      SpRailsSaml::Settings.assertion_consumer_service_url.present? &&
-        SpRailsSaml::Settings.sp_entity_id.present? &&
-        @saml_setting.idp_cert.present?
+      @saml_setting.idp_cert.present?
     end
 
     def ruby_saml_settings
       raise SettingValidationError, 'lack of required setting value' unless required_value_is_set?
 
       settings = OneLogin::RubySaml::Settings.new
-      settings.assertion_consumer_service_url = SpRailsSaml::Settings.assertion_consumer_service_url
-      settings.sp_entity_id                   = SpRailsSaml::Settings.sp_entity_id
-      settings.idp_cert                       = @saml_setting.idp_cert
+      settings.assertion_consumer_service_url     = saml_sso_url(id: @saml_setting.send(SpRailsSaml::Settings.account_class.to_s.downcase.to_sym).id)
+      settings.sp_entity_id                       = saml_metadata_url(id: @saml_setting.send(SpRailsSaml::Settings.account_class.to_s.downcase.to_sym).id)
+      settings.idp_cert                           = @saml_setting.idp_cert
+      settings.security[:want_assertions_signed]  =
+        SpRailsSaml::Settings::RUBY_SAML_DEFAULT_SETTINGS[:want_assertions_signed]
       settings
     end
   end

--- a/lib/sp-rails-saml/settings.rb
+++ b/lib/sp-rails-saml/settings.rb
@@ -3,17 +3,16 @@ module SpRailsSaml
   #
   class Settings
     RUBY_SAML_DEFAULT_SETTINGS = {
-      compress_request: false,
+      compress_request: true,
       skip_subject_confirmation: true,
-      skip_conditions: true
+      skip_conditions: true,
+      want_assertions_signed: true
     }.freeze
 
     class << self
-      attr_accessor :sp_entity_id,
-                    :name_identifier_format,
+      attr_accessor :name_identifier_format,
                     :authn_context,
                     :authn_context_comparison,
-                    :assertion_consumer_service_url,
                     :user_class,
                     :account_class
 

--- a/sp-rails-saml.gemspec
+++ b/sp-rails-saml.gemspec
@@ -28,4 +28,6 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
+
+  spec.add_dependency('ruby-saml')
 end

--- a/spec/fixtures/controllers/ssos_controller.rb
+++ b/spec/fixtures/controllers/ssos_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Saml
+  class SsosController < SsosBaseController
+    # POST /saml/sso/:id
+    # def consume
+    #   super
+    # end
+
+    # GET /saml/metadata/:id
+    # def metadata
+    #   super
+    # end
+  end
+end

--- a/spec/generators/sp_rails_saml/controllers_generator_spec.rb
+++ b/spec/generators/sp_rails_saml/controllers_generator_spec.rb
@@ -8,5 +8,6 @@ RSpec.describe SpRailsSaml::ControllersGenerator, type: :generator do
 
   it "should create saml_settings initializer file" do
     assert_file "app/controllers/saml/sessions_controller.rb", file_fixture('controllers/sessions_controller.rb')
+    assert_file "app/controllers/saml/ssos_controller.rb", file_fixture('controllers/ssos_controller.rb')
   end
 end

--- a/spec/generators/sp_rails_saml/settings_generator_spec.rb
+++ b/spec/generators/sp_rails_saml/settings_generator_spec.rb
@@ -9,11 +9,9 @@ RSpec.describe SpRailsSaml::ConfigGenerator, type: :generator do
   let(:initializer_text) do
 <<-EOS
 SpRailsSaml::Settings.setup do |config|
-  config.sp_entity_id                   = ''
   config.name_identifier_format         = 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'
   config.authn_context                  = 'urn:oasis:names:tc:SAML:2.0:ac:classes:X509'
   config.authn_context_comparison       = 'exact'
-  config.assertion_consumer_service_url = ''
   config.user_class = User
   config.account_class = Account
 end

--- a/spec/sp_rails_saml/authnrequest_spec.rb
+++ b/spec/sp_rails_saml/authnrequest_spec.rb
@@ -1,65 +1,92 @@
 RSpec.describe SpRailsSaml::Authnrequest do
   describe '#to_url' do
-    let(:saml_setting) { OpenStruct.new(idp_sso_url: 'https://example.com', idp_entity_id: 'https://example.com') }
+    let(:saml_setting) { OpenStruct.new(idp_sso_url: 'https://example.com', idp_entity_id: 'https://example.com', account: OpenStruct.new(id: 1)) }
     let(:sp_entity_id) { 'https://example.com' }
     let(:name_identifier_format) { 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress' }
     let(:authn_context) { 'urn:oasis:names:tc:SAML:2.0:ac:classes:X509' }
     let(:authn_context_comparison) { 'exact' }
     let(:assertion_consumer_service_url) { 'https://example.com' }
 
+    let!(:authnrequest) { SpRailsSaml::Authnrequest.new(saml_setting) }
+
     before do
+      allow(authnrequest).to receive(:saml_sso_url).and_return(assertion_consumer_service_url)
+      allow(authnrequest).to receive(:saml_metadata_url).and_return(sp_entity_id)
+
       SpRailsSaml::Settings.setup do |config|
-        config.sp_entity_id = sp_entity_id
         config.name_identifier_format = name_identifier_format
         config.authn_context = authn_context
         config.authn_context_comparison = authn_context_comparison
-        config.assertion_consumer_service_url = assertion_consumer_service_url
+        config.account_class = 'Account'
       end
     end
 
     it 'should create sso_url with saml request' do
-      sso_url = SpRailsSaml::Authnrequest.new(saml_setting).to_url
-      expect(sso_url).to match(/^https:\/\/example\.com\?SAMLRequest=/)
+      expect(authnrequest.to_url).to match(/^https:\/\/example\.com\?SAMLRequest=/)
     end
 
     it 'should create Authnrequest tag' do
-      sso_url = SpRailsSaml::Authnrequest.new(saml_setting).to_url
+      sso_url = authnrequest.to_url
       saml_request = CGI.unescape(sso_url.split("=").last)
 
       decoded_saml_request = Base64.decode64(saml_request)
-      doc = REXML::Document.new(decoded_saml_request)
+
+      zstream  = Zlib::Inflate.new(-Zlib::MAX_WBITS)
+      inflated = zstream.inflate(decoded_saml_request)
+      zstream.finish
+      zstream.close
+
+      doc = REXML::Document.new(inflated)
 
       expect(doc.elements['samlp:AuthnRequest']['Destination']).to eq saml_setting.idp_sso_url
       expect(doc.elements['samlp:AuthnRequest']['AssertionConsumerServiceURL']).to eq assertion_consumer_service_url
     end
 
     it 'should create Issuer tag' do
-      sso_url = SpRailsSaml::Authnrequest.new(saml_setting).to_url
+      sso_url = authnrequest.to_url
       saml_request = CGI.unescape(sso_url.split("=").last)
 
       decoded_saml_request = Base64.decode64(saml_request)
-      doc = REXML::Document.new(decoded_saml_request)
+
+      zstream  = Zlib::Inflate.new(-Zlib::MAX_WBITS)
+      inflated = zstream.inflate(decoded_saml_request)
+      zstream.finish
+      zstream.close
+
+      doc = REXML::Document.new(inflated)
 
       expect(doc.elements['samlp:AuthnRequest/saml:Issuer'].text.strip).to eq sp_entity_id
     end
 
     it 'should create RequestAuthnContext tag' do
-      sso_url = SpRailsSaml::Authnrequest.new(saml_setting).to_url
+      sso_url = authnrequest.to_url
       saml_request = CGI.unescape(sso_url.split("=").last)
 
       decoded_saml_request = Base64.decode64(saml_request)
-      doc = REXML::Document.new(decoded_saml_request)
+
+      zstream  = Zlib::Inflate.new(-Zlib::MAX_WBITS)
+      inflated = zstream.inflate(decoded_saml_request)
+      zstream.finish
+      zstream.close
+
+      doc = REXML::Document.new(inflated)
 
       expect(doc.elements['samlp:AuthnRequest/samlp:RequestedAuthnContext']['Comparison']).to eq authn_context_comparison
       expect(doc.elements['samlp:AuthnRequest/samlp:RequestedAuthnContext/saml:AuthnContextClassRef'].text.strip).to eq authn_context
     end
 
     it 'should create NameIDPolicy tag' do
-      sso_url = SpRailsSaml::Authnrequest.new(saml_setting).to_url
+      sso_url = authnrequest.to_url
       saml_request = CGI.unescape(sso_url.split("=").last)
 
       decoded_saml_request = Base64.decode64(saml_request)
-      doc = REXML::Document.new(decoded_saml_request)
+
+      zstream  = Zlib::Inflate.new(-Zlib::MAX_WBITS)
+      inflated = zstream.inflate(decoded_saml_request)
+      zstream.finish
+      zstream.close
+
+      doc = REXML::Document.new(inflated)
 
       expect(doc.elements['samlp:AuthnRequest/samlp:NameIDPolicy']['Format']).to eq name_identifier_format
     end

--- a/spec/sp_rails_saml/metadata_spec.rb
+++ b/spec/sp_rails_saml/metadata_spec.rb
@@ -1,0 +1,57 @@
+RSpec.describe SpRailsSaml::SamlResponse do
+  let(:saml_setting) { OpenStruct.new(idp_sso_url: 'https://example.com', idp_entity_id: 'https://example.com', account: OpenStruct.new(id: 1)) }
+  let(:sp_entity_id) { 'https://example.com/sp' }
+  let(:name_identifier_format) { 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress' }
+  let(:authn_context) { 'urn:oasis:names:tc:SAML:2.0:ac:classes:X509' }
+  let(:authn_context_comparison) { 'exact' }
+  let(:assertion_consumer_service_url) { 'https://example.com/acs' }
+
+  let(:metadata) { SpRailsSaml::Metadata.new(account: saml_setting.account) }
+
+  before do
+    allow(metadata).to receive(:saml_sso_url).and_return(assertion_consumer_service_url)
+    allow(metadata).to receive(:saml_metadata_url).and_return(sp_entity_id)
+
+    SpRailsSaml::Settings.setup do |config|
+      config.name_identifier_format = name_identifier_format
+    end
+  end
+
+  describe '#metadata' do
+    it 'should set entity_id' do
+      doc = REXML::Document.new(metadata.generate)
+
+      expect(doc.elements['md:EntityDescriptor']['entityID']).to eq sp_entity_id
+    end
+
+    it 'should set AuthnRequestsSigned false' do
+      doc = REXML::Document.new(metadata.generate)
+
+      expect(doc.elements['md:EntityDescriptor/md:SPSSODescriptor']['AuthnRequestsSigned']).to eq 'false'
+    end
+
+    it 'should set WantAssertionsSigned' do
+      doc = REXML::Document.new(metadata.generate)
+
+      expect(doc.elements['md:EntityDescriptor/md:SPSSODescriptor']['WantAssertionsSigned']).to eq 'true'
+    end
+
+    it 'should set NameIdFormat' do
+      doc = REXML::Document.new(metadata.generate)
+
+      expect(doc.elements['md:EntityDescriptor/md:SPSSODescriptor/md:NameIDFormat'].text.strip).to eq name_identifier_format
+    end
+
+    it 'should set AssertionConsumerService Binding' do
+      doc = REXML::Document.new(metadata.generate)
+
+      expect(doc.elements['md:EntityDescriptor/md:SPSSODescriptor/md:AssertionConsumerService']['Binding']).to eq 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST'
+    end
+
+    it 'should set AssertionConsumerService Location' do
+      doc = REXML::Document.new(metadata.generate)
+
+      expect(doc.elements['md:EntityDescriptor/md:SPSSODescriptor/md:AssertionConsumerService']['Location']).to eq assertion_consumer_service_url
+    end
+  end
+end

--- a/spec/sp_rails_saml/saml_response_spec.rb
+++ b/spec/sp_rails_saml/saml_response_spec.rb
@@ -8,11 +8,10 @@ RSpec.describe SpRailsSaml::SamlResponse do
 
   before do
     SpRailsSaml::Settings.setup do |config|
-      config.sp_entity_id = sp_entity_id
       config.name_identifier_format = name_identifier_format
       config.authn_context = authn_context
       config.authn_context_comparison = authn_context_comparison
-      config.assertion_consumer_service_url = assertion_consumer_service_url
+      config.account_class = 'Account'
     end
   end
 
@@ -20,58 +19,67 @@ RSpec.describe SpRailsSaml::SamlResponse do
     let(:saml_setting) {
       OpenStruct.new(
         idp_entity_id: 'http://localhost:3000/saml/metadata/kti85Q2miJBbOnvxBIEgYA',
-        idp_cert: file_fixture('certificate')
+        idp_cert: file_fixture('certificate'),
+        account: OpenStruct.new(id: 1)
       )
     }
 
-    context 'when valid saml response' do
-      it 'should return true' do
-        saml_response = SpRailsSaml::SamlResponse.new(saml_response_base64_str, saml_setting)
+    let(:saml_response) { SpRailsSaml::SamlResponse.new(saml_response_base64_str, saml_setting) }
 
+    context 'when valid saml response' do
+      before do
+        allow(saml_response).to receive(:saml_sso_url).and_return(assertion_consumer_service_url)
+        allow(saml_response).to receive(:saml_metadata_url).and_return(sp_entity_id)
+      end
+
+      it 'should return true' do
         expect(saml_response.valid?).to be_truthy
       end
     end
 
     context 'when sp_entity_id is not equal issuer' do
       before do
-        SpRailsSaml::Settings.setup({sp_entity_id: 'dummy'})
+        allow(saml_response).to receive(:saml_sso_url).and_return(assertion_consumer_service_url)
+        allow(saml_response).to receive(:saml_metadata_url).and_return('dummy')
       end
 
       it 'should return false' do
-        saml_response = SpRailsSaml::SamlResponse.new(saml_response_base64_str, saml_setting)
         expect(saml_response.valid?).to be_falsey
       end
     end
 
     context 'when certificate is not valid' do
       before do
+        allow(saml_response).to receive(:saml_sso_url).and_return(assertion_consumer_service_url)
+        allow(saml_response).to receive(:saml_metadata_url).and_return(sp_entity_id)
         saml_setting.idp_cert = file_fixture('wrong_certificate')
       end
 
       it 'should return false' do
-        saml_response = SpRailsSaml::SamlResponse.new(saml_response_base64_str, saml_setting)
         expect(saml_response.valid?).to be_falsey
       end
     end
 
     context 'when assertion_consumer_service_url is not equal Destination' do
       before do
-        SpRailsSaml::Settings.setup({assertion_consumer_service_url: 'dummy'})
+        allow(saml_response).to receive(:saml_sso_url).and_return('dummy')
+        allow(saml_response).to receive(:saml_metadata_url).and_return(sp_entity_id)
       end
 
       it 'should return false' do
-        saml_response = SpRailsSaml::SamlResponse.new(saml_response_base64_str, saml_setting)
         expect(saml_response.valid?).to be_falsey
       end
     end
 
     context 'lack of setting value' do
       before do
-        SpRailsSaml::Settings.setup({assertion_consumer_service_url: nil})
+        allow(saml_response).to receive(:saml_sso_url).and_return(assertion_consumer_service_url)
+        allow(saml_response).to receive(:saml_metadata_url).and_return(sp_entity_id)
+        saml_setting.idp_cert = nil
       end
 
       it 'should return SettingValidationError' do
-        expect { SpRailsSaml::SamlResponse.new(saml_response_base64_str, saml_setting) }.to raise_error(SpRailsSaml::SettingValidationError)
+        expect { saml_response.response }.to raise_error(SpRailsSaml::SettingValidationError)
       end
     end
   end
@@ -80,12 +88,19 @@ RSpec.describe SpRailsSaml::SamlResponse do
     let(:saml_setting) {
       OpenStruct.new(
         idp_entity_id: 'http://localhost:3000/saml/metadata/kti85Q2miJBbOnvxBIEgYA',
-        idp_cert: file_fixture('certificate')
+        idp_cert: file_fixture('certificate'),
+        account: OpenStruct.new(id: 1)
       )
     }
 
+    let(:saml_response) { SpRailsSaml::SamlResponse.new(saml_response_base64_str, saml_setting) }
+
+    before do
+      allow(saml_response).to receive(:saml_sso_url).and_return(assertion_consumer_service_url)
+      allow(saml_response).to receive(:saml_metadata_url).and_return(sp_entity_id)
+    end
+
     it 'should return name_id' do
-      saml_response = SpRailsSaml::SamlResponse.new(saml_response_base64_str, saml_setting)
       expect(saml_response.name_id).to eq 'test@example.com'
     end
   end
@@ -94,12 +109,19 @@ RSpec.describe SpRailsSaml::SamlResponse do
     let(:saml_setting) {
       OpenStruct.new(
         idp_entity_id: 'http://localhost:3000/saml/metadata/kti85Q2miJBbOnvxBIEgYA',
-        idp_cert: file_fixture('certificate')
+        idp_cert: file_fixture('certificate'),
+        account: OpenStruct.new(id: 1)
       )
     }
 
+    let(:saml_response) { SpRailsSaml::SamlResponse.new(saml_response_base64_str, saml_setting) }
+
+    before do
+      allow(saml_response).to receive(:saml_sso_url).and_return(assertion_consumer_service_url)
+      allow(saml_response).to receive(:saml_metadata_url).and_return(sp_entity_id)
+    end
+
     it 'should return name_identifier_format' do
-      saml_response = SpRailsSaml::SamlResponse.new(saml_response_base64_str, saml_setting)
       expect(saml_response.name_id_format).to eq name_identifier_format
     end
   end
@@ -108,18 +130,22 @@ RSpec.describe SpRailsSaml::SamlResponse do
     let(:saml_setting) {
       OpenStruct.new(
         idp_entity_id: 'http://localhost:3000/saml/metadata/kti85Q2miJBbOnvxBIEgYA',
-        idp_cert: file_fixture('certificate')
+        idp_cert: file_fixture('certificate'),
+        account: OpenStruct.new(id: 1)
       )
     }
 
+    let(:saml_response) { SpRailsSaml::SamlResponse.new(saml_response_base64_str, saml_setting) }
+
+
     context 'when sp_entity_id is not equal issuer' do
       before do
-        SpRailsSaml::Settings.setup({sp_entity_id: 'dummy'})
+        allow(saml_response).to receive(:saml_sso_url).and_return(assertion_consumer_service_url)
+        allow(saml_response).to receive(:saml_metadata_url).and_return('dummy')
       end
 
       # エラーに関してはruby-samlの内容をそのまま渡しているだけなので、エラーが返ってくることのみ検証して、それぞれの設定値に対するエラー内容の検証は行いません。
       it 'should return error messages' do
-        saml_response = SpRailsSaml::SamlResponse.new(saml_response_base64_str, saml_setting)
         saml_response.valid?
 
         expect(saml_response.errors).to eq ['Invalid Audience. The audience https://example.com/sp, did not match the expected audience dummy']

--- a/spec/sp_rails_saml/settings_spec.rb
+++ b/spec/sp_rails_saml/settings_spec.rb
@@ -13,20 +13,16 @@ RSpec.describe SpRailsSaml::Settings do
 
     it 'should set settings value' do
       SpRailsSaml::Settings.setup do |config|
-        config.sp_entity_id = sp_entity_id
         config.name_identifier_format = name_identifier_format
         config.authn_context = authn_context
         config.authn_context_comparison = authn_context_comparison
-        config.assertion_consumer_service_url = assertion_consumer_service_url
         config.user_class = user_class
         config.account_class = account_class
       end
 
-      expect(SpRailsSaml::Settings.sp_entity_id).to eq sp_entity_id
       expect(SpRailsSaml::Settings.name_identifier_format).to eq name_identifier_format
       expect(SpRailsSaml::Settings.authn_context).to eq authn_context
       expect(SpRailsSaml::Settings.authn_context_comparison).to eq authn_context_comparison
-      expect(SpRailsSaml::Settings.assertion_consumer_service_url).to eq assertion_consumer_service_url
       expect(SpRailsSaml::Settings.user_class).to eq user_class
       expect(SpRailsSaml::Settings.account_class).to eq account_class
     end


### PR DESCRIPTION
## 📎 関連リンク

[Growi 仕様](https://mcloud.growi.cloud/MCOSS/SSO%E6%A9%9F%E8%83%BD)

## ✅ やったこと

- SSO機能(Responseの検証、Metadataの表示)の実装

## 📝 やらなかったこと
- ライブラリ内で用意する`controller`に関するテストの実装
  - `controller spec`を実装しようとしたのですが、`get :index`みたいな形で対象のcontrollerにリクエストを投げてテストするのがこのgem内のrspecで実現するのが難しく、一旦実装は行っていません。
  - 対応方法がわかり次第対応したいと思います。

## 👀 導入までの流れ

- `gem`を追加
  - `gem 'sp-rails-saml', path: 'gemのpath'`

- `rails g sp_rails_saml:views`を実行
- `rails g sp_rails_saml:config`を実行
- `routes.rb`に`sp_rails_saml_routes`を追記

- `/saml/sign_in`にアクセス
  - ログインフォームが表示される

- メールアドレスを入力してボタンをクリックするとsaml_requestが投げられる

実際に自分で仮で作ったデモアプリに導入する際に発生した差分はこちら https://github.com/Sibakeny/sp/commit/292cad31795a72a1e8939f9ef8c98b972fe6863c

参考までに実際のSAML連携の動き↓

https://user-images.githubusercontent.com/35982148/120969552-3d7c0000-c7a5-11eb-9af9-cd4bbe461b5b.mov




