### PR TITLE
setupメソッドを再度実行できない様に実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,6 @@ gem 'ruby-saml'
 
 group :test do
   gem 'generator_spec'
+  gem 'pry'
   gem 'rails', '~> 6.1.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
     builder (3.2.4)
+    coderay (1.1.3)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
     diff-lcs (1.4.4)
@@ -92,6 +93,9 @@ GEM
     nokogiri (1.11.5)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     racc (1.5.2)
     rack (2.2.3)
     rack-test (1.1.0)
@@ -160,6 +164,7 @@ PLATFORMS
 
 DEPENDENCIES
   generator_spec
+  pry
   rails (~> 6.1.0)
   rake (~> 13.0)
   rspec (~> 3.0)

--- a/lib/sp-rails-saml.rb
+++ b/lib/sp-rails-saml.rb
@@ -13,6 +13,8 @@ module SpRailsSaml
 
   class SettingValidationError < Error; end
 
+  class MultiSetupError < Error; end
+
   autoload :Authnrequest, File.expand_path('./sp-rails-saml/authnrequest', __dir__)
   autoload :SamlResponse, File.expand_path('./sp-rails-saml/saml_response', __dir__)
   autoload :Metadata, File.expand_path('./sp-rails-saml/metadata', __dir__)

--- a/lib/sp-rails-saml/authnrequest.rb
+++ b/lib/sp-rails-saml/authnrequest.rb
@@ -24,11 +24,13 @@ module SpRailsSaml
     def ruby_saml_settings
       settings = OneLogin::RubySaml::Settings.new
 
-      settings.assertion_consumer_service_url = saml_sso_url(id: @saml_setting.send(SpRailsSaml::Settings.account_class.to_s.downcase.to_sym).id)
-      settings.sp_entity_id                   = saml_metadata_url(id: @saml_setting.send(SpRailsSaml::Settings.account_class.to_s.downcase.to_sym).id)
-      settings.name_identifier_format         = SpRailsSaml::Settings.name_identifier_format
-      settings.authn_context                  = SpRailsSaml::Settings.authn_context
-      settings.authn_context_comparison       = SpRailsSaml::Settings.authn_context_comparison
+      sp_rails_saml_setting = SpRailsSaml::Settings.instance
+
+      settings.assertion_consumer_service_url = saml_sso_url(id: @saml_setting.send(sp_rails_saml_setting.account_class.to_s.downcase.to_sym).id)
+      settings.sp_entity_id                   = saml_metadata_url(id: @saml_setting.send(sp_rails_saml_setting.account_class.to_s.downcase.to_sym).id)
+      settings.name_identifier_format         = sp_rails_saml_setting.name_identifier_format
+      settings.authn_context                  = sp_rails_saml_setting.authn_context
+      settings.authn_context_comparison       = sp_rails_saml_setting.authn_context_comparison
       settings.idp_entity_id                  = @saml_setting.idp_entity_id
       settings.idp_sso_service_url            = @saml_setting.idp_sso_url
       settings.compress_request               = SpRailsSaml::Settings::RUBY_SAML_DEFAULT_SETTINGS[:compress_request]

--- a/lib/sp-rails-saml/metadata.rb
+++ b/lib/sp-rails-saml/metadata.rb
@@ -28,9 +28,11 @@ module SpRailsSaml
 
       settings = OneLogin::RubySaml::Settings.new
 
+      sp_rails_saml_setting = SpRailsSaml::Settings.instance
+
       settings.assertion_consumer_service_url     = saml_sso_url(@account.id)
       settings.sp_entity_id                       = saml_metadata_url(@account.id)
-      settings.name_identifier_format             = SpRailsSaml::Settings.name_identifier_format
+      settings.name_identifier_format             = sp_rails_saml_setting.name_identifier_format
       settings.security[:want_assertions_signed]  =
         SpRailsSaml::Settings::RUBY_SAML_DEFAULT_SETTINGS[:want_assertions_signed]
       settings

--- a/lib/sp-rails-saml/saml_response.rb
+++ b/lib/sp-rails-saml/saml_response.rb
@@ -52,8 +52,11 @@ module SpRailsSaml
       raise SettingValidationError, 'lack of required setting value' unless required_value_is_set?
 
       settings = OneLogin::RubySaml::Settings.new
-      settings.assertion_consumer_service_url     = saml_sso_url(id: @saml_setting.send(SpRailsSaml::Settings.account_class.to_s.downcase.to_sym).id)
-      settings.sp_entity_id                       = saml_metadata_url(id: @saml_setting.send(SpRailsSaml::Settings.account_class.to_s.downcase.to_sym).id)
+
+      sp_rails_saml_setting = SpRailsSaml::Settings.instance
+
+      settings.assertion_consumer_service_url     = saml_sso_url(id: @saml_setting.send(sp_rails_saml_setting.account_class.to_s.downcase.to_sym).id)
+      settings.sp_entity_id                       = saml_metadata_url(id: @saml_setting.send(sp_rails_saml_setting.account_class.to_s.downcase.to_sym).id)
       settings.idp_cert                           = @saml_setting.idp_cert
       settings.security[:want_assertions_signed]  =
         SpRailsSaml::Settings::RUBY_SAML_DEFAULT_SETTINGS[:want_assertions_signed]

--- a/lib/sp-rails-saml/settings.rb
+++ b/lib/sp-rails-saml/settings.rb
@@ -1,13 +1,26 @@
+require 'singleton'
+
+# rubocop:disable Style/ClassVars
 module SpRailsSaml
   # SAML2 settings for initializer.
   #
   class Settings
+    include Singleton
+
     RUBY_SAML_DEFAULT_SETTINGS = {
       compress_request: true,
       skip_subject_confirmation: true,
       skip_conditions: true,
       want_assertions_signed: true
     }.freeze
+
+    attr_reader :name_identifier_format,
+                :authn_context,
+                :authn_context_comparison,
+                :user_class,
+                :account_class
+
+    @@setuped = false
 
     class << self
       attr_accessor :name_identifier_format,
@@ -16,12 +29,22 @@ module SpRailsSaml
                     :user_class,
                     :account_class
 
-      def setup(options = {})
-        options.each do |key, value|
-          instance_variable_set("@#{key}", value)
-        end
-        yield(self) if block_given?
+      def setup
+        raise SpRailsSaml::MultiSetupError if @@setuped
+
+        yield self
+
+        setting = SpRailsSaml::Settings.instance
+
+        setting.instance_variable_set(:@name_identifier_format, SpRailsSaml::Settings.name_identifier_format)
+        setting.instance_variable_set(:@authn_context, SpRailsSaml::Settings.authn_context)
+        setting.instance_variable_set(:@authn_context_comparison, SpRailsSaml::Settings.authn_context_comparison)
+        setting.instance_variable_set(:@user_class, SpRailsSaml::Settings.user_class)
+        setting.instance_variable_set(:@account_class, SpRailsSaml::Settings.account_class)
+
+        @@setuped = true
       end
     end
   end
 end
+# rubocop:enable Style/ClassVars

--- a/spec/sp_rails_saml/authnrequest_spec.rb
+++ b/spec/sp_rails_saml/authnrequest_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe SpRailsSaml::Authnrequest do
     let!(:authnrequest) { SpRailsSaml::Authnrequest.new(saml_setting) }
 
     before do
+      SpRailsSaml::Settings.class_variable_set(:@@setuped, false)
+
       allow(authnrequest).to receive(:saml_sso_url).and_return(assertion_consumer_service_url)
       allow(authnrequest).to receive(:saml_metadata_url).and_return(sp_entity_id)
 

--- a/spec/sp_rails_saml/metadata_spec.rb
+++ b/spec/sp_rails_saml/metadata_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe SpRailsSaml::SamlResponse do
   let(:metadata) { SpRailsSaml::Metadata.new(account: saml_setting.account) }
 
   before do
+    SpRailsSaml::Settings.class_variable_set(:@@setuped, false)
+
     allow(metadata).to receive(:saml_sso_url).and_return(assertion_consumer_service_url)
     allow(metadata).to receive(:saml_metadata_url).and_return(sp_entity_id)
 

--- a/spec/sp_rails_saml/saml_response_spec.rb
+++ b/spec/sp_rails_saml/saml_response_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe SpRailsSaml::SamlResponse do
   let(:assertion_consumer_service_url) { 'https://example.com/acs' }
 
   before do
+    SpRailsSaml::Settings.class_variable_set(:@@setuped, false)
+
     SpRailsSaml::Settings.setup do |config|
       config.name_identifier_format = name_identifier_format
       config.authn_context = authn_context

--- a/spec/sp_rails_saml/settings_spec.rb
+++ b/spec/sp_rails_saml/settings_spec.rb
@@ -1,3 +1,5 @@
+require 'pry'
+
 RSpec.describe SpRailsSaml::Settings do
   class User; end
   class Account; end
@@ -11,6 +13,10 @@ RSpec.describe SpRailsSaml::Settings do
     let(:user_class) { User }
     let(:account_class) { Account }
 
+    before do
+      SpRailsSaml::Settings.class_variable_set(:@@setuped, false)
+    end
+
     it 'should set settings value' do
       SpRailsSaml::Settings.setup do |config|
         config.name_identifier_format = name_identifier_format
@@ -20,11 +26,34 @@ RSpec.describe SpRailsSaml::Settings do
         config.account_class = account_class
       end
 
-      expect(SpRailsSaml::Settings.name_identifier_format).to eq name_identifier_format
-      expect(SpRailsSaml::Settings.authn_context).to eq authn_context
-      expect(SpRailsSaml::Settings.authn_context_comparison).to eq authn_context_comparison
-      expect(SpRailsSaml::Settings.user_class).to eq user_class
-      expect(SpRailsSaml::Settings.account_class).to eq account_class
+      sp_rails_saml_setting = SpRailsSaml::Settings.instance
+
+      expect(sp_rails_saml_setting.name_identifier_format).to eq name_identifier_format
+      expect(sp_rails_saml_setting.authn_context).to eq authn_context
+      expect(sp_rails_saml_setting.authn_context_comparison).to eq authn_context_comparison
+      expect(sp_rails_saml_setting.user_class).to eq user_class
+      expect(sp_rails_saml_setting.account_class).to eq account_class
+    end
+
+    it 'raise if twice setup' do
+      SpRailsSaml::Settings.setup do |config|
+        config.name_identifier_format = name_identifier_format
+        config.authn_context = authn_context
+        config.authn_context_comparison = authn_context_comparison
+        config.user_class = user_class
+        config.account_class = account_class
+      end
+
+      expect {
+        SpRailsSaml::Settings.setup do |config|
+          config.name_identifier_format = name_identifier_format
+        end
+      }.to raise_error(SpRailsSaml::MultiSetupError)
+    end
+
+    it 'raise if set setting value' do
+      sp_rails_saml_setting = SpRailsSaml::Settings.instance
+      expect { sp_rails_saml_setting.name_identifier_format = 'new_value' }.to raise_error(NoMethodError)
     end
   end
 end


### PR DESCRIPTION
## 📎 関連リンク

fixes https://github.com/metaps/sp-rails-saml/issues/24

## ✅ やったこと

- setupメソッドを複数回実行できない様に修正
  - 二度目のsetupメソッドを実行時は `SpRailsSaml::MultiSetupError `エラーが発生する様にしています。

- シングルトンオブジェクトに直接値を設定できない様に修正
  - attr_readerを使用しても`instance_variable_set`メソッドを使用すれば値の設定ができてしまいます。
  - ただ、主な目的としては実装上で謝って値の更新をしてしまう場合などを避ける目的だと思うので基本的な(setting.authncontext = '〇〇')の様な形で値の設定ができなければ十分だと思っています。


シングルトンオブジェクトですが、任意のタイミングでオブジェクトを生成できるかと思ったのですがそうではなく最初からオブジェクトが用意されており、`new`メソッドでインスタンスを生成する作業は必要ありませんでした。

そのため実装としては`setup`メソッドを実行したらクラス変数に一旦値を持ち、そこからシングルトンオブジェクトに値を設定するような方法をとっています。

## 📝 やらなかったこと





