### PR TITLE
アプリ導入の際に必要になった機能の追加

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sp-rails-saml (1.0.0)
+    sp-rails-saml (1.0.1)
       ruby-saml
 
 GEM

--- a/app/controllers/saml/saml_settings_base_controller.rb
+++ b/app/controllers/saml/saml_settings_base_controller.rb
@@ -1,22 +1,25 @@
 module Saml
   # Controller to register saml by SP
   class SamlSettingsBaseController < SamlBaseController
-    # GET /saml/SpRailsSaml::Settings.account_class.to_s.downcase/:#{SpRailsSaml::Settings.account_class.to_s.downcase}_id/saml_settings
+    # GET /saml/account_class/:#{account_class}_#{account_find_key}/saml_settings
     def show
-      account = SpRailsSaml::Settings.account_class.find_by(id: params["#{SpRailsSaml::Settings.account_class.to_s.downcase}_id"])
-      @saml_setting = SamlSetting.find_or_initialize_by("#{SpRailsSaml::Settings.account_class.to_s.downcase}_id" => account.id)
+      setting = SpRailsSaml::Settings.instance
+      account = setting.account_class.find_by(setting.account_find_key => params["#{setting.account_class.to_s.downcase}_#{setting.account_find_key}"])
+      @saml_setting = account.saml_setting.present? ? account_saml_setting : account.build_smal_setting
     end
 
-    # GET /saml/SpRailsSaml::Settings.account_class.to_s.downcase/:#{SpRailsSaml::Settings.account_class.to_s.downcase}_id/saml_settings/edit
+    # GET /saml/account_class/:#{account_class}_#{account_find_key}/saml_settings/edit
     def edit
-      account = SpRailsSaml::Settings.account_class.find_by(id: params["#{SpRailsSaml::Settings.account_class.to_s.downcase}_id"])
-      @saml_setting = SamlSetting.find_or_initialize_by("#{SpRailsSaml::Settings.account_class.to_s.downcase}_id" => account.id)
+      setting = SpRailsSaml::Settings.instance
+      account = setting.account_class.find_by(setting.account_find_key => params["#{setting.account_class.to_s.downcase}_#{setting.account_find_key}"])
+      @saml_setting = account.saml_setting.present? ? account_saml_setting : account.build_smal_setting
     end
 
-    # PATCH /saml/SpRailsSaml::Settings.account_class.to_s.downcase/:#{SpRailsSaml::Settings.account_class.to_s.downcase}_id/saml_settings
+    # PATCH /saml/account_class/:#{account_class}_#{account_find_key}/saml_settings
     def update
-      account = SpRailsSaml::Settings.account_class.find_by(id: params["#{SpRailsSaml::Settings.account_class.to_s.downcase}_id"])
-      @saml_setting = SamlSetting.find_or_initialize_by("#{SpRailsSaml::Settings.account_class.to_s.downcase}_id" => account.id)
+      setting = SpRailsSaml::Settings.instance
+      account = setting.account_class.find_by(setting.account_find_key => params["#{setting.account_class.to_s.downcase}_#{setting.account_find_key}"])
+      @saml_setting = account.saml_setting.present? ? account_saml_setting : account.build_smal_setting
 
       @saml_setting.assign_attributes(saml_setting_params)
 

--- a/app/controllers/saml/saml_settings_base_controller.rb
+++ b/app/controllers/saml/saml_settings_base_controller.rb
@@ -4,22 +4,22 @@ module Saml
     # GET /saml/account_class/:#{account_class}_#{account_find_key}/saml_settings
     def show
       setting = SpRailsSaml::Settings.instance
-      account = setting.account_class.find_by(setting.account_find_key => params["#{setting.account_class.to_s.downcase}_#{setting.account_find_key}"])
-      @saml_setting = account.saml_setting.present? ? account_saml_setting : account.build_smal_setting
+      account = setting.account_class.find_by!(setting.account_find_key => params["#{setting.account_class.to_s.downcase}_#{setting.account_find_key}"])
+      @saml_setting = account.saml_setting.present? ? account.saml_setting : account.build_smal_setting
     end
 
     # GET /saml/account_class/:#{account_class}_#{account_find_key}/saml_settings/edit
     def edit
       setting = SpRailsSaml::Settings.instance
-      account = setting.account_class.find_by(setting.account_find_key => params["#{setting.account_class.to_s.downcase}_#{setting.account_find_key}"])
-      @saml_setting = account.saml_setting.present? ? account_saml_setting : account.build_smal_setting
+      account = setting.account_class.find_by!(setting.account_find_key => params["#{setting.account_class.to_s.downcase}_#{setting.account_find_key}"])
+      @saml_setting = account.saml_setting.present? ? account.saml_setting : account.build_smal_setting
     end
 
     # PATCH /saml/account_class/:#{account_class}_#{account_find_key}/saml_settings
     def update
       setting = SpRailsSaml::Settings.instance
-      account = setting.account_class.find_by(setting.account_find_key => params["#{setting.account_class.to_s.downcase}_#{setting.account_find_key}"])
-      @saml_setting = account.saml_setting.present? ? account_saml_setting : account.build_smal_setting
+      account = setting.account_class.find_by!(setting.account_find_key => params["#{setting.account_class.to_s.downcase}_#{setting.account_find_key}"])
+      @saml_setting = account.saml_setting.present? ? account.saml_setting : account.build_smal_setting
 
       @saml_setting.assign_attributes(saml_setting_params)
 

--- a/app/controllers/saml/saml_settings_controller.rb
+++ b/app/controllers/saml/saml_settings_controller.rb
@@ -1,17 +1,17 @@
 module Saml
   # Controller to register saml by SP
   class SamlSettingsController < SamlSettingsBaseController
-    # GET /saml/SpRailsSaml::Settings.account_class.to_s.downcase/:#{SpRailsSaml::Settings.account_class.to_s.downcase}_id/saml_settings
+    # GET /saml/account_class/:#{account_class}_#{account_find_key}/saml_settings
     # def show
     #   super
     # end
 
-    # GET /saml/SpRailsSaml::Settings.account_class.to_s.downcase/:#{SpRailsSaml::Settings.account_class.to_s.downcase}_id/saml_settings/edit
+    # GET /saml/account_class/:#{account_class}_#{account_find_key}/saml_settings/edit
     # def edit
     #   super
     # end
 
-    # PATCH /saml/SpRailsSaml::Settings.account_class.to_s.downcase/:#{SpRailsSaml::Settings.account_class.to_s.downcase}_id/saml_settings
+    # PATCH /saml/account_class/:#{account_class}_#{account_find_key}/saml_settings
     # def update
     #   super
     # end

--- a/app/controllers/saml/sessions_base_controller.rb
+++ b/app/controllers/saml/sessions_base_controller.rb
@@ -7,9 +7,9 @@ module Saml
 
     # POST /saml/sign_in
     def create
-      user = SpRailsSaml::Settings.user_class.find_by(setting.user_find_key => params[:email])
-      settings = SpRailsSaml::Settings.instance
-      account = user.send(settings.account_class.to_s.downcase.to_sym)
+      setting = SpRailsSaml::Settings.instance
+      user = setting.user_class.find_by(setting.user_find_key => params[:email])
+      account = user.send(setting.account_class.to_s.downcase.to_sym)
 
       raise SpRailsSaml::SamlLoginForbidden if account.saml_setting.password_only?
 

--- a/app/controllers/saml/sessions_base_controller.rb
+++ b/app/controllers/saml/sessions_base_controller.rb
@@ -7,8 +7,9 @@ module Saml
 
     # POST /saml/sign_in
     def create
-      user = SpRailsSaml::Settings.user_class.find_by(email: params[:email])
-      account = user.send(SpRailsSaml::Settings.account_class.to_s.downcase.to_sym)
+      user = SpRailsSaml::Settings.user_class.find_by(setting.user_find_key => params[:email])
+      settings = SpRailsSaml::Settings.instance
+      account = user.send(settings.account_class.to_s.downcase.to_sym)
 
       raise SpRailsSaml::SamlLoginForbidden if account.saml_setting.password_only?
 

--- a/app/controllers/saml/sessions_base_controller.rb
+++ b/app/controllers/saml/sessions_base_controller.rb
@@ -8,7 +8,7 @@ module Saml
     # POST /saml/sign_in
     def create
       setting = SpRailsSaml::Settings.instance
-      user = setting.user_class.find_by(setting.user_find_key => params[:email])
+      user = setting.user_class.find_by!(setting.user_find_key => params[:email])
       account = user.send(setting.account_class.to_s.downcase.to_sym)
 
       raise SpRailsSaml::SamlLoginForbidden if account.saml_setting.password_only?

--- a/app/controllers/saml/ssos_base_controller.rb
+++ b/app/controllers/saml/ssos_base_controller.rb
@@ -16,7 +16,7 @@ module Saml
 
       raise SpRailsSaml::SamlResponseInvalid, saml_response.errors unless saml_response.valid?
 
-      user = setting.user_class.find_by(setting.user_find_key => saml_response.name_id)
+      user = setting.user_class.find_by(setting.saml_response_user_find_key => saml_response.name_id)
 
       raise SpRailsSaml::LoginUserNotFound if user.blank?
 

--- a/app/controllers/saml/ssos_base_controller.rb
+++ b/app/controllers/saml/ssos_base_controller.rb
@@ -7,7 +7,7 @@ module Saml
     # POST /saml/metadata/:id
     def consume
       setting = SpRailsSaml::Settings.instance
-      account = setting.account_class.find_by(setting.account_find_key => params[setting.account_find_key])
+      account = setting.account_class.find_by!(setting.account_find_key => params[setting.account_find_key])
 
       raise SpRailsSaml::SamlLoginForbidden if account.saml_setting.password_only?
 
@@ -26,7 +26,7 @@ module Saml
     # GET /saml/metadata/:id
     def metadata
       setting = SpRailsSaml::Settings.instance
-      account = setting.account_class.find_by(setting.account_find_key => params[setting.account_find_key])
+      account = setting.account_class.find_by!(setting.account_find_key => params[setting.account_find_key])
       metadata = SpRailsSaml::Metadata.new(account: account)
       render xml: metadata.generate
     end

--- a/app/controllers/saml/ssos_base_controller.rb
+++ b/app/controllers/saml/ssos_base_controller.rb
@@ -6,26 +6,27 @@ module Saml
 
     # POST /saml/metadata/:id
     def consume
-      account = SpRailsSaml::Settings.account_class.find(params[:id])
+      setting = SpRailsSaml::Settings.instance
+      account = setting.account_class.find_by(setting.account_find_key => params[setting.account_find_key])
 
       raise SpRailsSaml::SamlLoginForbidden if account.saml_setting.password_only?
 
       saml_setting = account.saml_setting
       saml_response = SpRailsSaml::SamlResponse.new(params[:SAMLResponse], saml_setting)
 
-      if saml_response.valid?
-        user = SpRailsSaml::Settings.user_class.find_by(email: saml_response.name_id)
-        raise LoginUserNotFound if user.blank?
+      raise SpRailsSaml::SamlResponseInvalid, saml_response.errors unless saml_response.valid?
 
-        sign_in_with_saml(user)
-      else
-        redirect_to saml_sign_in_path, alert: 'failed to login'
-      end
+      user = setting.user_class.find_by(setting.user_find_key => saml_response.name_id)
+
+      raise SpRailsSaml::LoginUserNotFound if user.blank?
+
+      sign_in_with_saml(user)
     end
 
     # GET /saml/metadata/:id
     def metadata
-      account = SpRailsSaml::Settings.account_class.find(params[:id])
+      setting = SpRailsSaml::Settings.instance
+      account = setting.account_class.find_by(setting.account_find_key => params[setting.account_find_key])
       metadata = SpRailsSaml::Metadata.new(account: account)
       render xml: metadata.generate
     end

--- a/lib/generators/sp-rails-saml/config_generator.rb
+++ b/lib/generators/sp-rails-saml/config_generator.rb
@@ -14,12 +14,14 @@ module SpRailsSaml
 
     def default_initializer
       <<~RUBY
-        SpRailsSaml::Settings.setup do |config|
-          config.name_identifier_format         = 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'
-          config.authn_context                  = 'urn:oasis:names:tc:SAML:2.0:ac:classes:X509'
-          config.authn_context_comparison       = 'exact'
-          config.user_class = User
-          config.account_class = Account
+        Rails.configuration.to_prepare do
+          SpRailsSaml::Settings.setup do |config|
+            config.name_identifier_format         = 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'
+            config.authn_context                  = 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport'
+            config.authn_context_comparison       = 'exact'
+            config.user_class                     = User
+            config.account_class                  = Account
+          end
         end
       RUBY
     end

--- a/lib/generators/sp-rails-saml/install_generator.rb
+++ b/lib/generators/sp-rails-saml/install_generator.rb
@@ -22,12 +22,14 @@ module SpRailsSaml
 
     def default_initializer
       <<~RUBY
-        SpRailsSaml::Settings.setup do |config|
-          config.name_identifier_format         = 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'
-          config.authn_context                  = 'urn:oasis:names:tc:SAML:2.0:ac:classes:X509'
-          config.authn_context_comparison       = 'exact'
-          config.user_class = User
-          config.account_class = Account
+        Rails.configuration.to_prepare do
+          SpRailsSaml::Settings.setup do |config|
+            config.name_identifier_format         = 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'
+            config.authn_context                  = 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport'
+            config.authn_context_comparison       = 'exact'
+            config.user_class                     = User
+            config.account_class                  = Account
+          end
         end
       RUBY
     end

--- a/lib/generators/sp-rails-saml/templates/controllers/saml_settings_controller.rb
+++ b/lib/generators/sp-rails-saml/templates/controllers/saml_settings_controller.rb
@@ -1,18 +1,17 @@
 module Saml
   # Controller to register saml by SP
-  #
   class SamlSettingsController < SamlSettingsBaseController
-    # GET /saml/SpRailsSaml::Settings.account_class.to_s.downcase/:#{SpRailsSaml::Settings.account_class.to_s.downcase}_id/saml_settings
+    # GET /saml/account_class/:#{account_class}_#{account_find_key}/saml_settings
     # def show
     #   super
     # end
 
-    # GET /saml/SpRailsSaml::Settings.account_class.to_s.downcase/:#{SpRailsSaml::Settings.account_class.to_s.downcase}_id/saml_settings/edit
+    # GET /saml/account_class/:#{account_class}_#{account_find_key}/saml_settings/edit
     # def edit
     #   super
     # end
 
-    # PATCH /saml/SpRailsSaml::Settings.account_class.to_s.downcase/:#{SpRailsSaml::Settings.account_class.to_s.downcase}_id/saml_settings
+    # PATCH /saml/account_class/:#{account_class}_#{account_find_key}/saml_settings
     # def update
     #   super
     # end

--- a/lib/sp-rails-saml.rb
+++ b/lib/sp-rails-saml.rb
@@ -14,8 +14,6 @@ module SpRailsSaml
 
   class SettingValidationError < Error; end
 
-  class MultiSetupError < Error; end
-
   class SamlLoginForbidden < Error; end
 
   class LoginUserNotFound < Error; end

--- a/lib/sp-rails-saml.rb
+++ b/lib/sp-rails-saml.rb
@@ -18,6 +18,10 @@ module SpRailsSaml
 
   class SamlLoginForbidden < Error; end
 
+  class LoginUserNotFound < Error; end
+
+  class SamlResponseInvalid < Error; end
+
   autoload :Authnrequest, File.expand_path('./sp-rails-saml/authnrequest', __dir__)
   autoload :SamlResponse, File.expand_path('./sp-rails-saml/saml_response', __dir__)
   autoload :Metadata, File.expand_path('./sp-rails-saml/metadata', __dir__)

--- a/lib/sp-rails-saml/authnrequest.rb
+++ b/lib/sp-rails-saml/authnrequest.rb
@@ -26,8 +26,12 @@ module SpRailsSaml
 
       sp_rails_saml_setting = SpRailsSaml::Settings.instance
 
-      settings.assertion_consumer_service_url = saml_sso_url(id: @saml_setting.send(sp_rails_saml_setting.account_class.to_s.downcase.to_sym).id)
-      settings.sp_entity_id                   = saml_metadata_url(id: @saml_setting.send(sp_rails_saml_setting.account_class.to_s.downcase.to_sym).id)
+      settings.assertion_consumer_service_url = saml_sp_consume_url(
+        @saml_setting.send(sp_rails_saml_setting.account_class.to_s.downcase.to_sym).send(sp_rails_saml_setting.account_find_key)
+      )
+      settings.sp_entity_id = saml_sp_metadata_url(
+        @saml_setting.send(sp_rails_saml_setting.account_class.to_s.downcase.to_sym).send(sp_rails_saml_setting.account_find_key)
+      )
       settings.name_identifier_format         = sp_rails_saml_setting.name_identifier_format
       settings.authn_context                  = sp_rails_saml_setting.authn_context
       settings.authn_context_comparison       = sp_rails_saml_setting.authn_context_comparison

--- a/lib/sp-rails-saml/metadata.rb
+++ b/lib/sp-rails-saml/metadata.rb
@@ -30,8 +30,8 @@ module SpRailsSaml
 
       sp_rails_saml_setting = SpRailsSaml::Settings.instance
 
-      settings.assertion_consumer_service_url     = saml_sso_url(@account.id)
-      settings.sp_entity_id                       = saml_metadata_url(@account.id)
+      settings.assertion_consumer_service_url     = saml_sp_consume_url(@account.send(sp_rails_saml_setting.account_find_key))
+      settings.sp_entity_id                       = saml_sp_metadata_url(@account.send(sp_rails_saml_setting.account_find_key))
       settings.name_identifier_format             = sp_rails_saml_setting.name_identifier_format
       settings.security[:want_assertions_signed]  =
         SpRailsSaml::Settings::RUBY_SAML_DEFAULT_SETTINGS[:want_assertions_signed]

--- a/lib/sp-rails-saml/routes/routes_template.rb
+++ b/lib/sp-rails-saml/routes/routes_template.rb
@@ -5,7 +5,7 @@ namespace :saml do
 
   unless @sso_only
     # Saml settings for SP
-    resources SpRailsSaml::Settings.instance.account_class.to_s.downcase.to_sym, only: [], param => SpRailsSaml::Settings.instance.account_find_key do
+    resources SpRailsSaml::Settings.instance.account_class.to_s.downcase.to_sym, only: [], param: SpRailsSaml::Settings.instance.account_find_key do
       resource :saml_settings, only: %i[show edit update]
     end
   end

--- a/lib/sp-rails-saml/routes/routes_template.rb
+++ b/lib/sp-rails-saml/routes/routes_template.rb
@@ -5,12 +5,12 @@ namespace :saml do
 
   unless @sso_only
     # Saml settings for SP
-    resources SpRailsSaml::Settings.account_class.to_s.downcase.to_sym, only: [] do
+    resources SpRailsSaml::Settings.instance.account_class.to_s.downcase.to_sym, only: [], param => SpRailsSaml::Settings.instance.account_find_key do
       resource :saml_settings, only: %i[show edit update]
     end
   end
 
   # SSO
-  post 'sso/:id', to: 'ssos#consume', as: :sso
-  get 'metadata/:id', to: 'ssos#metadata', as: :metadata
+  post "sp/consume/:#{SpRailsSaml::Settings.instance.account_find_key}", to: 'ssos#consume', as: :sp_consume
+  get "sp/metadata/:#{SpRailsSaml::Settings.instance.account_find_key}", to: 'ssos#metadata', as: :sp_metadata
 end

--- a/lib/sp-rails-saml/settings.rb
+++ b/lib/sp-rails-saml/settings.rb
@@ -1,6 +1,5 @@
 require 'singleton'
 
-# rubocop:disable Style/ClassVars
 module SpRailsSaml
   # SAML2 settings for initializer.
   #
@@ -25,8 +24,6 @@ module SpRailsSaml
                 :user_find_key,
                 :account_find_key
 
-    @@setuped = false
-
     class << self
       attr_accessor :name_identifier_format,
                     :authn_context,
@@ -37,8 +34,6 @@ module SpRailsSaml
                     :account_find_key
 
       def setup
-        raise SpRailsSaml::MultiSetupError if @@setuped
-
         yield self
 
         setting = SpRailsSaml::Settings.instance
@@ -50,10 +45,7 @@ module SpRailsSaml
         setting.instance_variable_set(:@account_class, SpRailsSaml::Settings.account_class)
         setting.instance_variable_set(:@user_find_key, SpRailsSaml::Settings.user_find_key || RUBY_SAML_DEFAULT_SETTINGS[:user_find_key])
         setting.instance_variable_set(:@account_find_key, SpRailsSaml::Settings.account_find_key || RUBY_SAML_DEFAULT_SETTINGS[:account_find_key])
-
-        @@setuped = true
       end
     end
   end
 end
-# rubocop:enable Style/ClassVars

--- a/lib/sp-rails-saml/settings.rb
+++ b/lib/sp-rails-saml/settings.rb
@@ -13,7 +13,8 @@ module SpRailsSaml
       skip_destination: false,
       want_assertions_signed: true,
       account_find_key: :id,
-      user_find_key: :email
+      user_find_key: :email,
+      saml_response_user_find_key: :email
     }.freeze
 
     attr_reader :name_identifier_format,
@@ -22,7 +23,8 @@ module SpRailsSaml
                 :user_class,
                 :account_class,
                 :user_find_key,
-                :account_find_key
+                :account_find_key,
+                :saml_response_user_find_key
 
     class << self
       attr_accessor :name_identifier_format,
@@ -31,7 +33,8 @@ module SpRailsSaml
                     :user_class,
                     :account_class,
                     :user_find_key,
-                    :account_find_key
+                    :account_find_key,
+                    :saml_response_user_find_key
 
       def setup
         yield self
@@ -45,6 +48,8 @@ module SpRailsSaml
         setting.instance_variable_set(:@account_class, SpRailsSaml::Settings.account_class)
         setting.instance_variable_set(:@user_find_key, SpRailsSaml::Settings.user_find_key || RUBY_SAML_DEFAULT_SETTINGS[:user_find_key])
         setting.instance_variable_set(:@account_find_key, SpRailsSaml::Settings.account_find_key || RUBY_SAML_DEFAULT_SETTINGS[:account_find_key])
+        setting.instance_variable_set(:@saml_response_user_find_key,
+                                      SpRailsSaml::Settings.saml_response_user_find_key || RUBY_SAML_DEFAULT_SETTINGS[:saml_response_user_find_key])
       end
     end
   end

--- a/lib/sp-rails-saml/settings.rb
+++ b/lib/sp-rails-saml/settings.rb
@@ -11,14 +11,19 @@ module SpRailsSaml
       compress_request: true,
       skip_subject_confirmation: true,
       skip_conditions: true,
-      want_assertions_signed: true
+      skip_destination: false,
+      want_assertions_signed: true,
+      account_find_key: :id,
+      user_find_key: :email
     }.freeze
 
     attr_reader :name_identifier_format,
                 :authn_context,
                 :authn_context_comparison,
                 :user_class,
-                :account_class
+                :account_class,
+                :user_find_key,
+                :account_find_key
 
     @@setuped = false
 
@@ -27,7 +32,9 @@ module SpRailsSaml
                     :authn_context,
                     :authn_context_comparison,
                     :user_class,
-                    :account_class
+                    :account_class,
+                    :user_find_key,
+                    :account_find_key
 
       def setup
         raise SpRailsSaml::MultiSetupError if @@setuped
@@ -41,6 +48,8 @@ module SpRailsSaml
         setting.instance_variable_set(:@authn_context_comparison, SpRailsSaml::Settings.authn_context_comparison)
         setting.instance_variable_set(:@user_class, SpRailsSaml::Settings.user_class)
         setting.instance_variable_set(:@account_class, SpRailsSaml::Settings.account_class)
+        setting.instance_variable_set(:@user_find_key, SpRailsSaml::Settings.user_find_key || RUBY_SAML_DEFAULT_SETTINGS[:user_find_key])
+        setting.instance_variable_set(:@account_find_key, SpRailsSaml::Settings.account_find_key || RUBY_SAML_DEFAULT_SETTINGS[:account_find_key])
 
         @@setuped = true
       end

--- a/lib/sp-rails-saml/version.rb
+++ b/lib/sp-rails-saml/version.rb
@@ -1,3 +1,3 @@
 module SpRailsSaml
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.0.1'.freeze
 end

--- a/spec/fixtures/controllers/saml_settings_controller.rb
+++ b/spec/fixtures/controllers/saml_settings_controller.rb
@@ -1,18 +1,17 @@
 module Saml
   # Controller to register saml by SP
-  #
   class SamlSettingsController < SamlSettingsBaseController
-    # GET /saml/SpRailsSaml::Settings.account_class.to_s.downcase/:#{SpRailsSaml::Settings.account_class.to_s.downcase}_id/saml_settings
+    # GET /saml/account_class/:#{account_class}_#{account_find_key}/saml_settings
     # def show
     #   super
     # end
 
-    # GET /saml/SpRailsSaml::Settings.account_class.to_s.downcase/:#{SpRailsSaml::Settings.account_class.to_s.downcase}_id/saml_settings/edit
+    # GET /saml/account_class/:#{account_class}_#{account_find_key}/saml_settings/edit
     # def edit
     #   super
     # end
 
-    # PATCH /saml/SpRailsSaml::Settings.account_class.to_s.downcase/:#{SpRailsSaml::Settings.account_class.to_s.downcase}_id/saml_settings
+    # PATCH /saml/account_class/:#{account_class}_#{account_find_key}/saml_settings
     # def update
     #   super
     # end

--- a/spec/fixtures/initializers/sp-rails-saml.rb
+++ b/spec/fixtures/initializers/sp-rails-saml.rb
@@ -1,7 +1,9 @@
-SpRailsSaml::Settings.setup do |config|
-  config.name_identifier_format         = 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'
-  config.authn_context                  = 'urn:oasis:names:tc:SAML:2.0:ac:classes:X509'
-  config.authn_context_comparison       = 'exact'
-  config.user_class = User
-  config.account_class = Account
+Rails.configuration.to_prepare do
+  SpRailsSaml::Settings.setup do |config|
+    config.name_identifier_format         = 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'
+    config.authn_context                  = 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport'
+    config.authn_context_comparison       = 'exact'
+    config.user_class                     = User
+    config.account_class                  = Account
+  end
 end

--- a/spec/sp_rails_saml/authnrequest_spec.rb
+++ b/spec/sp_rails_saml/authnrequest_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe SpRailsSaml::Authnrequest do
     before do
       SpRailsSaml::Settings.class_variable_set(:@@setuped, false)
 
-      allow(authnrequest).to receive(:saml_sso_url).and_return(assertion_consumer_service_url)
-      allow(authnrequest).to receive(:saml_metadata_url).and_return(sp_entity_id)
+      allow(authnrequest).to receive(:saml_sp_consume_url).and_return(assertion_consumer_service_url)
+      allow(authnrequest).to receive(:saml_sp_metadata_url).and_return(sp_entity_id)
 
       SpRailsSaml::Settings.setup do |config|
         config.name_identifier_format = name_identifier_format

--- a/spec/sp_rails_saml/metadata_spec.rb
+++ b/spec/sp_rails_saml/metadata_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe SpRailsSaml::SamlResponse do
+RSpec.describe SpRailsSaml::Metadata do
   let(:saml_setting) { OpenStruct.new(idp_sso_url: 'https://example.com', idp_entity_id: 'https://example.com', account: OpenStruct.new(id: 1)) }
   let(:sp_entity_id) { 'https://example.com/sp' }
   let(:name_identifier_format) { 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress' }
@@ -11,8 +11,8 @@ RSpec.describe SpRailsSaml::SamlResponse do
   before do
     SpRailsSaml::Settings.class_variable_set(:@@setuped, false)
 
-    allow(metadata).to receive(:saml_sso_url).and_return(assertion_consumer_service_url)
-    allow(metadata).to receive(:saml_metadata_url).and_return(sp_entity_id)
+    allow(metadata).to receive(:saml_sp_consume_url).and_return(assertion_consumer_service_url)
+    allow(metadata).to receive(:saml_sp_metadata_url).and_return(sp_entity_id)
 
     SpRailsSaml::Settings.setup do |config|
       config.name_identifier_format = name_identifier_format

--- a/spec/sp_rails_saml/saml_response_spec.rb
+++ b/spec/sp_rails_saml/saml_response_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe SpRailsSaml::SamlResponse do
 
     context 'when valid saml response' do
       before do
-        allow(saml_response).to receive(:saml_sso_url).and_return(assertion_consumer_service_url)
-        allow(saml_response).to receive(:saml_metadata_url).and_return(sp_entity_id)
+        allow(saml_response).to receive(:saml_sp_consume_url).and_return(assertion_consumer_service_url)
+        allow(saml_response).to receive(:saml_sp_metadata_url).and_return(sp_entity_id)
       end
 
       it 'should return true' do
@@ -41,8 +41,8 @@ RSpec.describe SpRailsSaml::SamlResponse do
 
     context 'when sp_entity_id is not equal issuer' do
       before do
-        allow(saml_response).to receive(:saml_sso_url).and_return(assertion_consumer_service_url)
-        allow(saml_response).to receive(:saml_metadata_url).and_return('dummy')
+        allow(saml_response).to receive(:saml_sp_consume_url).and_return(assertion_consumer_service_url)
+        allow(saml_response).to receive(:saml_sp_metadata_url).and_return('dummy')
       end
 
       it 'should return false' do
@@ -52,8 +52,8 @@ RSpec.describe SpRailsSaml::SamlResponse do
 
     context 'when certificate is not valid' do
       before do
-        allow(saml_response).to receive(:saml_sso_url).and_return(assertion_consumer_service_url)
-        allow(saml_response).to receive(:saml_metadata_url).and_return(sp_entity_id)
+        allow(saml_response).to receive(:saml_sp_consume_url).and_return(assertion_consumer_service_url)
+        allow(saml_response).to receive(:saml_sp_metadata_url).and_return(sp_entity_id)
         saml_setting.idp_cert = file_fixture('wrong_certificate')
       end
 
@@ -64,8 +64,8 @@ RSpec.describe SpRailsSaml::SamlResponse do
 
     context 'when assertion_consumer_service_url is not equal Destination' do
       before do
-        allow(saml_response).to receive(:saml_sso_url).and_return('dummy')
-        allow(saml_response).to receive(:saml_metadata_url).and_return(sp_entity_id)
+        allow(saml_response).to receive(:saml_sp_consume_url).and_return('dummy')
+        allow(saml_response).to receive(:saml_sp_metadata_url).and_return(sp_entity_id)
       end
 
       it 'should return false' do
@@ -73,11 +73,23 @@ RSpec.describe SpRailsSaml::SamlResponse do
       end
     end
 
-    context 'lack of setting value' do
+    context 'when idp_cert is blank' do
       before do
-        allow(saml_response).to receive(:saml_sso_url).and_return(assertion_consumer_service_url)
-        allow(saml_response).to receive(:saml_metadata_url).and_return(sp_entity_id)
+        allow(saml_response).to receive(:saml_sp_consume_url).and_return(assertion_consumer_service_url)
+        allow(saml_response).to receive(:saml_sp_metadata_url).and_return(sp_entity_id)
         saml_setting.idp_cert = nil
+      end
+
+      it 'should return SettingValidationError' do
+        expect { saml_response.response }.to raise_error(SpRailsSaml::SettingValidationError)
+      end
+    end
+
+    context 'when idp_entity_id is blank' do
+      before do
+        allow(saml_response).to receive(:saml_sp_consume_url).and_return(assertion_consumer_service_url)
+        allow(saml_response).to receive(:saml_sp_metadata_url).and_return(sp_entity_id)
+        saml_setting.idp_entity_id = nil
       end
 
       it 'should return SettingValidationError' do
@@ -98,8 +110,8 @@ RSpec.describe SpRailsSaml::SamlResponse do
     let(:saml_response) { SpRailsSaml::SamlResponse.new(saml_response_base64_str, saml_setting) }
 
     before do
-      allow(saml_response).to receive(:saml_sso_url).and_return(assertion_consumer_service_url)
-      allow(saml_response).to receive(:saml_metadata_url).and_return(sp_entity_id)
+      allow(saml_response).to receive(:saml_sp_consume_url).and_return(assertion_consumer_service_url)
+      allow(saml_response).to receive(:saml_sp_metadata_url).and_return(sp_entity_id)
     end
 
     it 'should return name_id' do
@@ -119,8 +131,8 @@ RSpec.describe SpRailsSaml::SamlResponse do
     let(:saml_response) { SpRailsSaml::SamlResponse.new(saml_response_base64_str, saml_setting) }
 
     before do
-      allow(saml_response).to receive(:saml_sso_url).and_return(assertion_consumer_service_url)
-      allow(saml_response).to receive(:saml_metadata_url).and_return(sp_entity_id)
+      allow(saml_response).to receive(:saml_sp_consume_url).and_return(assertion_consumer_service_url)
+      allow(saml_response).to receive(:saml_sp_metadata_url).and_return(sp_entity_id)
     end
 
     it 'should return name_identifier_format' do
@@ -141,8 +153,8 @@ RSpec.describe SpRailsSaml::SamlResponse do
 
     context 'when sp_entity_id is not equal issuer' do
       before do
-        allow(saml_response).to receive(:saml_sso_url).and_return(assertion_consumer_service_url)
-        allow(saml_response).to receive(:saml_metadata_url).and_return('dummy')
+        allow(saml_response).to receive(:saml_sp_consume_url).and_return(assertion_consumer_service_url)
+        allow(saml_response).to receive(:saml_sp_metadata_url).and_return('dummy')
       end
 
       # エラーに関してはruby-samlの内容をそのまま渡しているだけなので、エラーが返ってくることのみ検証して、それぞれの設定値に対するエラー内容の検証は行いません。

--- a/spec/sp_rails_saml/settings_spec.rb
+++ b/spec/sp_rails_saml/settings_spec.rb
@@ -42,22 +42,6 @@ RSpec.describe SpRailsSaml::Settings do
       expect(sp_rails_saml_setting.account_find_key).to eq account_find_key
     end
 
-    it 'raise if twice setup' do
-      SpRailsSaml::Settings.setup do |config|
-        config.name_identifier_format = name_identifier_format
-        config.authn_context = authn_context
-        config.authn_context_comparison = authn_context_comparison
-        config.user_class = user_class
-        config.account_class = account_class
-      end
-
-      expect {
-        SpRailsSaml::Settings.setup do |config|
-          config.name_identifier_format = name_identifier_format
-        end
-      }.to raise_error(SpRailsSaml::MultiSetupError)
-    end
-
     it 'raise if set setting value' do
       sp_rails_saml_setting = SpRailsSaml::Settings.instance
       expect { sp_rails_saml_setting.name_identifier_format = 'new_value' }.to raise_error(NoMethodError)

--- a/spec/sp_rails_saml/settings_spec.rb
+++ b/spec/sp_rails_saml/settings_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe SpRailsSaml::Settings do
     let(:assertion_consumer_service_url) { 'assertion_consumer_service_url' }
     let(:user_class) { User }
     let(:account_class) { Account }
+    let(:user_find_key) { :label }
+    let(:account_find_key) { :label }
 
     before do
       SpRailsSaml::Settings.class_variable_set(:@@setuped, false)
@@ -25,6 +27,8 @@ RSpec.describe SpRailsSaml::Settings do
         config.authn_context_comparison = authn_context_comparison
         config.user_class = user_class
         config.account_class = account_class
+        config.user_find_key = user_find_key
+        config.account_find_key = account_find_key
       end
 
       sp_rails_saml_setting = SpRailsSaml::Settings.instance
@@ -34,6 +38,8 @@ RSpec.describe SpRailsSaml::Settings do
       expect(sp_rails_saml_setting.authn_context_comparison).to eq authn_context_comparison
       expect(sp_rails_saml_setting.user_class).to eq user_class
       expect(sp_rails_saml_setting.account_class).to eq account_class
+      expect(sp_rails_saml_setting.user_find_key).to eq user_find_key
+      expect(sp_rails_saml_setting.account_find_key).to eq account_find_key
     end
 
     it 'raise if twice setup' do

--- a/spec/sp_rails_saml/settings_spec.rb
+++ b/spec/sp_rails_saml/settings_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe SpRailsSaml::Settings do
     let(:account_class) { Account }
     let(:user_find_key) { :label }
     let(:account_find_key) { :label }
+    let(:saml_response_user_find_key) { :label }
 
     before do
       SpRailsSaml::Settings.class_variable_set(:@@setuped, false)
@@ -29,6 +30,7 @@ RSpec.describe SpRailsSaml::Settings do
         config.account_class = account_class
         config.user_find_key = user_find_key
         config.account_find_key = account_find_key
+        config.saml_response_user_find_key = saml_response_user_find_key
       end
 
       sp_rails_saml_setting = SpRailsSaml::Settings.instance
@@ -40,6 +42,7 @@ RSpec.describe SpRailsSaml::Settings do
       expect(sp_rails_saml_setting.account_class).to eq account_class
       expect(sp_rails_saml_setting.user_find_key).to eq user_find_key
       expect(sp_rails_saml_setting.account_find_key).to eq account_find_key
+      expect(sp_rails_saml_setting.saml_response_user_find_key).to eq saml_response_user_find_key
     end
 
     it 'raise if set setting value' do


### PR DESCRIPTION
## 📎 関連リンク

## ✅ やったこと

- routingの修正
  - acs_urlを`/saml/sso/:id` から `/saml/sp/consume/:id` に修正
  - metadata_urlを`/saml/metadata/:id` から `/saml/sp/metadata/:id`に修正

- ユーザー、アカウントを検索する際に使用するカラムを変更できる様に修正
  - config.user_find_keyを指定すると、entityIdからユーザーを検索する際に使用するカラムを指定できる機能を追加(デフォルトは`email`)
  - config.account_find_keyを指定するとユーザーの検索する際に使用するカラムを指定できる機能を追加(デフォルトは`id`)

- 設定値の読み込み時に下記の警告が発生していたので警告が出ないように修正しました。
  - 警告文に記載の通り、設定値読み込みのコードを`Rails.configuration.to_prepare do`内に記載する様に修正しました。

```
DEPRECATION WARNING: Initialization autoloaded the constants ApplicationRecord, PasswordComplexityValidator, User, and Account.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload ApplicationRecord, for example,
the expected changes won't be reflected in that stale Class object.

These autoloaded constants have been unloaded.

In order to autoload safely at boot time, please wrap your code in a reloader
callback this way:

  Rails.application.reloader.to_prepare do
    # Autoload classes and modules needed at boot time here.
  end

That block runs when the application boots, and every time there is a reload.
For historical reasons, it may run twice, so it has to be idempotent.

Check the "Autoloading and Reloading Constants" guide to learn more about how
Rails autoloads and reloads.
```

- 設定値の参照に関して定数から参照している箇所があったので`SpRailsSaml::Settings.instance`から参照する様に修正


- idp_entity_idが`NULL`の場合にruby-samlの仕様で `issuer == idp_entity_id`の検証が行われないため、値が設定されていない場合はエラーを発生させる様に修正

- ライブラリの微修正を行いましたのでバージョンを `1.0.0` => `1.0.1`に変更しました。

## 📝 やらなかったこと

## 👀確認方法







